### PR TITLE
Update tooling, enabling tests v3 and v4 to pass

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,8 +1,15 @@
 System.config({
   "baseURL": "/",
   "transpiler": "babel",
+  "babelOptions": {
+    "optional": [
+      "runtime"
+    ]
+  },
   "paths": {
-    "*": "*.js"
+    "*": "*.js",
+    "github:*": "jspm_packages/github/*.js",
+    "npm:*": "jspm_packages/npm/*.js"
   },
   "bundles": {
     "build": [
@@ -10,6 +17,23 @@ System.config({
       "src/triple",
       "src/index"
     ]
+  }
+});
+
+System.config({
+  "map": {
+    "babel": "npm:babel-core@5.2.6",
+    "babel-runtime": "npm:babel-runtime@5.2.6",
+    "core-js": "npm:core-js@0.9.6",
+    "github:jspm/nodelibs-process@0.1.1": {
+      "process": "npm:process@0.10.1"
+    },
+    "npm:core-js@0.8.4": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:core-js@0.9.6": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    }
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -17,21 +17,21 @@
   },
   "homepage": "https://github.com/micahasmith/babel-test",
   "devDependencies": {
-    "babel": "^4.6.6",
-    "es6-module-loader": "^0.11.2",
     "jasmine-core": "^2.2.0",
-    "jspm": "^0.14.0",
+    "jspm": "^0.15.5",
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.4",
-    "systemjs": "^0.11.3",
-    "traceur": "0.0.85"
+    "karma-jspm": "^1.1.4"
   },
   "jspm": {
     "directories": {
-      "lib": ".",
-      "packages": "jspm_packages"
+      "lib": "."
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.1.13",
+      "babel-runtime": "npm:babel-runtime@^5.1.13",
+      "core-js": "npm:core-js@^0.9.4"
     }
   }
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -94,3 +94,22 @@ describe('swapping out deps v4',function(){
 		expect(index(2,3)).toEqual( 2+3 );
 	});
 });
+
+describe('swapping out deps v5',function(){
+	var index;
+	beforeEach(function(done) {
+		// import replacements
+		System.map["src/triple"] = "test/fakes/identity";
+		System.map["src/double"] = "test/fakes/identity";
+
+		// import src/index, hopefully with new funcs
+		System.import('src/index').then(function(ind) {
+			index = ind.default;
+			done();
+		});
+	});
+
+	it('works',function() {
+		expect(index(2,3)).toEqual( 2+3 );
+	});
+});


### PR DESCRIPTION
Hi, I'm researching testing es6 modules in a babel+jspm workflow,
and wanted to document how systemjs/systemjs#366 is resolved.

I updated to the latest systemjs tooling, pruned unused npm deps,
and added babel via jspm, and now tests v3 and v4 pass.

**Update:** Added a test which omits the `delete`s, and still passes. 
